### PR TITLE
Cleanup and expose RAPT interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The important changes from the original SPTK are summerized as follows:
 - Remove `wavsplit` and `wavjoin` from target sources to compile for cross-platform compilation ability, since original `wavsplit` and `wavjoin` use `direct.h` that only exists in POSIX enviroments. ([#8])
 - Add `DLLEXPORT` macro to expose API functions explicitly in MSVC environments (NOTE: this is not fully used for now)  ([#8])
 - Ensure c89 compatibility
+- Export excite function (#[11])
+- Cleanup and export RAPT function (#[12])
 
 ## Installation
 
@@ -47,3 +49,5 @@ sudo ./waf install
 
 
 [#8]: https://github.com/r9y9/SPTK/pull/8
+[#11]: https://github.com/r9y9/SPTK/pull/11
+[#12]: https://github.com/r9y9/SPTK/pull/12

--- a/bin/excite/_excite.c
+++ b/bin/excite/_excite.c
@@ -54,8 +54,8 @@
 *               -p p     :  frame period                        [100]   *
 *               -i i     :  interpolation period                [1]     *
 *               -n       :  gauss/M-sequence flag for unoiced   [FALSE] *
-*                           default is M-sequence                       *   
-*               -s s     :  seed for nrand                      [1]     * 
+*                           default is M-sequence                       *
+*               -s s     :  seed for nrand                      [1]     *
 *      infile:                                                          *
 *               pitch data                                              *
 *      stdout:                                                          *
@@ -64,9 +64,6 @@
 *               mseq()                                                  *
 *                                                                       *
 ************************************************************************/
-
-static char *rcs_id = "$Id: excite.c,v 1.25 2014/12/11 08:30:34 uratec Exp $";
-
 
 /*  Standard C Libraries  */
 #include <stdio.h>

--- a/bin/pitch/snack/jkGetF0.c
+++ b/bin/pitch/snack/jkGetF0.c
@@ -1537,16 +1537,7 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
 
     if (actsize > total_samps)
       actsize = total_samps;
-
-    /*    if (1) {
-      int res = Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", (double) ndone / sound->length);
-      if (res != TCL_OK) {
-	return TCL_ERROR;
-      }
-      }*/
   }
-
-  /*Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", 1.0);*/
 
   for (i = 0; i < fnum; i++) {
       switch (otype) {

--- a/bin/pitch/snack/jkGetF0.c
+++ b/bin/pitch/snack/jkGetF0.c
@@ -137,11 +137,10 @@ check_f0_params(F0_params *par, double sample_freq)
 
 
 /* ----------------------------------------------------------------------- */
-void get_fast_cands(fdata, fdsdata, ind, step, size, dec, start, nlags, engref, maxloc, maxval, cp, peaks, locs, ncand, par)
-     float *fdata, *fdsdata, *engref, *maxval, *peaks;
-     int size, start, nlags, *maxloc, *locs, *ncand, ind, step, dec;
-     Cross *cp;
-     F0_params *par;
+void get_fast_cands(float *fdata, float *fdsdata, int ind, int step, int size,
+                    int dec, int start, int nlags, float *engref, int *maxloc,
+                    float *maxval, Cross *cp, float *peaks, int *locs,
+                    int *ncand, F0_params *par)
 {
   int decind, decstart, decnlags, decsize, i, j, *lp;
   float *corp, xp, yp, lag_wt;
@@ -220,10 +219,8 @@ void get_fast_cands(fdata, fdsdata, ind, step, size, dec, start, nlags, engref, 
 }
 
 /* ----------------------------------------------------------------------- */
-float *downsample(input,samsin,state_idx,freq,samsout,decimate, first_time, last_time)
-     double freq;
-     float *input;
-      int samsin, *samsout, decimate, state_idx, first_time, last_time;
+float *downsample(float *input, int samsin, int state_idx, double freq,
+                  int *samsout, int decimate, int first_time, int last_time)
 {
   static float	b[2048];
   static float *foutput = NULL;
@@ -269,11 +266,8 @@ float *downsample(input,samsin,state_idx,freq,samsout,decimate, first_time, last
 
 /* ----------------------------------------------------------------------- */
 /* Get likely candidates for F0 peaks. */
-static void get_cand(cross,peak,loc,nlags,ncand,cand_thresh)
-     Cross *cross;
-     float *peak, cand_thresh;
-     int *loc;
-     int  *ncand, nlags;
+static void get_cand(Cross *cross, float *peak, int *loc, int nlags, int *ncand,
+       float cand_thresh)
 {
   register int i, lastl, *t;
   register float o, p, q, *r, *s, clip;
@@ -419,12 +413,9 @@ int idx;
 }
 
 /*      ----------------------------------------------------------      */
-static int lc_lin_fir(fc,nf,coef)
+static int lc_lin_fir(register float fc, int *nf, float* coef)
 /* create the coefficients for a symmetric FIR lowpass filter using the
    window technique with a Hanning window. */
-register float	fc;
-float	*coef;
-int	*nf;
 {
     register int	i, n;
     register double	twopi, fn, c;
@@ -453,9 +444,9 @@ int	*nf;
 /* ----------------------------------------------------------------------- */
 /* Use parabolic interpolation over the three points defining the peak
  * vicinity to estimate the "true" peak. */
-static void peak(y, xp, yp)
-     float *y,			/* vector of length 3 defining peak */
-       *xp, *yp;  /* x,y values of parabolic peak fitting the input points. */
+static void peak(float *y, float *xp, float *yp)
+/* vector of length 3 defining peak */
+/* x,y values of parabolic peak fitting the input points. */
 {
   register float a, c;
 
@@ -564,10 +555,7 @@ static int first_time = 1, pad;
 
 
 /*--------------------------------------------------------------------*/
-int
-get_Nframes(buffsize, pad, step)
-    long    buffsize;
-    int     pad, step;
+int get_Nframes(long buffsize, int pad, int step)
 {
   if (buffsize < pad)
     return (0);
@@ -577,11 +565,7 @@ get_Nframes(buffsize, pad, step)
 
 
 /*--------------------------------------------------------------------*/
-int
-init_dp_f0(freq, par, buffsize, sdstep)
-    double	freq;
-    F0_params	*par;
-    long	*buffsize, *sdstep;
+int init_dp_f0(double freq, F0_params *par, long *buffsize, long *sdstep)
 {
   int nframes;
   int i;
@@ -722,15 +706,9 @@ init_dp_f0(freq, par, buffsize, sdstep)
 
 
 /*--------------------------------------------------------------------*/
-int
-dp_f0(fdata, buff_size, sdstep, freq,
-      par, f0p_pt, vuvp_pt, rms_speech_pt, acpkp_pt, vecsize, last_time)
-    float	*fdata;
-    int		buff_size, sdstep;
-    double	freq;
-    F0_params	*par;		/* analysis control parameters */
-    float	**f0p_pt, **vuvp_pt, **rms_speech_pt, **acpkp_pt;
-    int		*vecsize, last_time;
+int dp_f0(float *fdata, int buff_size, int sdstep, double freq, F0_params *par,
+          float **f0p_pt, float **vuvp_pt, float **rms_speech_pt,
+          float **acpkp_pt, int *vecsize, int last_time)
 {
   float  maxval, engref, *sta, *rms_ratio, *dsdata;
   register float ttemp, ftemp, ft1, ferr, err, errmin;
@@ -1066,9 +1044,7 @@ num_active_frames);
 
 
 /*--------------------------------------------------------------------*/
-Frame *
-alloc_frame(nlags, ncands)
-    int     nlags, ncands;
+Frame *alloc_frame(int nlags, int ncands)
 {
   Frame *frm;
   int j;
@@ -1096,11 +1072,7 @@ alloc_frame(nlags, ncands)
 /* push window stat to stack, and pop the oldest one */
 
 static int
-save_windstat(rho, order, err, rms)
-    float   *rho;
-    int     order;
-    float   err;
-    float   rms;
+save_windstat(float *rho, int order, float err, float rms)
 {
     int i,j;
 
@@ -1126,11 +1098,7 @@ save_windstat(rho, order, err, rms)
 
 /*--------------------------------------------------------------------*/
 static int
-retrieve_windstat(rho, order, err, rms)
-    float   *rho;
-    int     order;
-    float   *err;
-    float   *rms;
+retrieve_windstat(float *rho, int order, float *err, float *rms)
 {
     Windstat wstat;
     int i;
@@ -1147,13 +1115,9 @@ retrieve_windstat(rho, order, err, rms)
 
 
 /*--------------------------------------------------------------------*/
-static float
-get_similarity(order, size, pdata, cdata,
-	       rmsa, rms_ratio, pre, stab, w_type, init)
-    int     order, size;
-    float   *pdata, *cdata;
-    float   *rmsa, *rms_ratio, pre, stab;
-    int     w_type, init;
+static float get_similarity(int order, int size, float *pdata, float *cdata,
+       float *rmsa, float *rms_ratio, float pre, float stab, int w_type,
+       int init)
 {
   float rho3[BIGSORD+1], err3, rms3, rmsd3, b0, t, a2[BIGSORD+1],
       rho1[BIGSORD+1], a1[BIGSORD+1], b[BIGSORD+1], err1, rms1, rmsd1;
@@ -1228,11 +1192,8 @@ get_similarity(order, size, pdata, cdata,
 static Stat *stat = NULL;
 static float *mem = NULL;
 
-static Stat*
-get_stationarity(fdata, freq, buff_size, nframes, frame_step, first_time)
-    float   *fdata;
-    double  freq;
-    int     buff_size, nframes, frame_step, first_time;
+static Stat* get_stationarity(float *fdata, double freq, int buff_size,
+       int  nframes, int frame_step, int first_time)
 {
   static int nframes_old = 0, memsize;
   float preemp = 0.4f, stab = 30.0f;
@@ -1326,9 +1287,7 @@ get_stationarity(fdata, freq, buff_size, nframes, frame_step, first_time)
 /* -------------------------------------------------------------------- */
 /*	Round the argument to the nearest integer.			*/
 
-int
-eround(flnum)
-    double  flnum;
+int eround(double flnum)
 {
   return((flnum >= 0.0) ? (int)(flnum + 0.5) : (int)(flnum - 0.5));
 }

--- a/bin/pitch/snack/jkGetF0.c
+++ b/bin/pitch/snack/jkGetF0.c
@@ -3,7 +3,7 @@
  * by Microsoft Corp. with the terms in the accompanying file BSD.txt,
  * which is a BSD style license.
  *
- *    "Copyright (c) 1990-1996 Entropic Research Laboratory, Inc. 
+ *    "Copyright (c) 1990-1996 Entropic Research Laboratory, Inc.
  *                   All rights reserved"
  *
  * Written by:  Derek Lin
@@ -64,9 +64,6 @@
 
 *****************************************************************/
 
-#if 0
-#include "snack.h"
-#endif /* 0 */
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -77,11 +74,7 @@
 # define FALSE 0
 #endif
 #ifndef FLT_MAX
-#if 0
-# define FLT_MAX (3.40282347E+38f) 
-#else
-# define FLT_MAX (3.40282346E+38f) 
-#endif
+#define FLT_MAX (3.40282346E+38f)
 #endif
 #ifndef M_PI
 # define M_PI (3.1415926536f)
@@ -90,295 +83,31 @@
 
 int	    debug_level = 0;
 
-void free_dp_f0();
-#if 0
-#else
+static void free_dp_f0();
 static int check_f0_params();
-typedef struct _float_list {
-    float f;
-    struct _float_list *next;
-} float_list;
-#endif /* 0 */
-
-#if 0
-int
-Get_f0(Sound *sound, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
-{
-  float *fdata;
-  int done;
-  long buff_size, actsize;
-  double sf, start_time;
-  F0_params *par, *read_f0_params();
-  float *f0p, *vuvp, *rms_speech, *acpkp;
-  int i, vecsize;
-  int init_dp_f0(), dp_f0();
-  static int framestep = -1;
-  long sdstep = 0, total_samps;
-  int ndone = 0;
-  Tcl_Obj *list;
-  double framestep2 = 0.0, wind_dur;
-
-  int arg, startpos = 0, endpos = -1, fmax, fmin;
-  static CONST84 char *subOptionStrings[] = {
-    "-start", "-end", "-maxpitch", "-minpitch", "-progress",
-    "-framelength", "-method", "-windowlength", NULL
-  };
-  enum subOptions {
-    START, END, F0MAX, F0MIN, PROGRESS, FRAME, METHOD, WINLEN
-  };
-
-  if (sound->cmdPtr != NULL) {
-    Tcl_DecrRefCount(sound->cmdPtr);
-    sound->cmdPtr = NULL;
-  }
-
-  par = (F0_params *) ckalloc(sizeof(F0_params));
-  par->cand_thresh = 0.3f;
-  par->lag_weight = 0.3f;
-  par->freq_weight = 0.02f;
-  par->trans_cost = 0.005f;
-  par->trans_amp = 0.5f;
-  par->trans_spec = 0.5f;
-  par->voice_bias = 0.0f;
-  par->double_cost = 0.35f;
-  par->min_f0 = 50;
-  par->max_f0 = 550;
-  par->frame_step = 0.01f;
-  par->wind_dur = 0.0075f;
-  par->n_cands = 20;
-  par->mean_f0 = 200;     /* unused */
-  par->mean_f0_weight = 0.0f;  /* unused */
-  par->conditioning = 0;    /*unused */
-
-  for (arg = 2; arg < objc; arg += 2) {
-    int index;
-	
-    if (Tcl_GetIndexFromObj(interp, objv[arg], subOptionStrings,
-			    "option", 0, &index) != TCL_OK) {
-      return TCL_ERROR;
-    }
-
-    if (arg + 1 == objc) {
-      Tcl_AppendResult(interp, "No argument given for ",
-		       subOptionStrings[index], " option", (char *) NULL);
-      return TCL_ERROR;
-    }
-    
-    switch ((enum subOptions) index) {
-    case START:
-      {
-	if (Tcl_GetIntFromObj(interp, objv[arg+1], &startpos) != TCL_OK)
-	  return TCL_ERROR;
-	break;
-      }
-    case END:
-      {
-	if (Tcl_GetIntFromObj(interp, objv[arg+1], &endpos) != TCL_OK)
-	  return TCL_ERROR;
-	break;
-      }
-    case F0MAX:
-      {
-	if (Tcl_GetIntFromObj(interp, objv[arg+1], &fmax) != TCL_OK)
-	  return TCL_ERROR;
-	par->max_f0 = (float) fmax;
-	break;
-      }
-    case F0MIN:
-      {
-	if (Tcl_GetIntFromObj(interp, objv[arg+1], &fmin) != TCL_OK)
-	  return TCL_ERROR;
-	par->min_f0 = (float) fmin;
-	break;
-      }
-    case PROGRESS:
-      {
-	char *str = Tcl_GetStringFromObj(objv[arg+1], NULL);
-	
-	if (strlen(str) > 0) {
-	  Tcl_IncrRefCount(objv[arg+1]);
-	  sound->cmdPtr = objv[arg+1];
-	}
-	break;
-      }
-    case FRAME:
-      {
-	if (Tcl_GetDoubleFromObj(interp, objv[arg+1], &framestep2)
-	    != TCL_OK)
-	  return TCL_ERROR;
-	par->frame_step = (float) framestep2;
-	break;
-      }
-    case METHOD:
-      {
-	break;
-      }
-    case WINLEN:
-      {
-	if (Tcl_GetDoubleFromObj(interp, objv[arg+1], &wind_dur)
-	    != TCL_OK)
-	  return TCL_ERROR;
-	par->wind_dur = (float) wind_dur;
-	break;
-      }
-    }
-  }
-  if (startpos < 0) startpos = 0;
-  if (endpos >= (sound->length - 1) || endpos == -1)
-    endpos = sound->length - 1;
-  if (startpos > endpos) return TCL_OK;
-
-  sf = (double) sound->samprate;
-
-  if (framestep > 0)  /* If a value was specified with -S, use it. */
-    par->frame_step = (float) (framestep / sf);
-  start_time = 0.0f;
-  if(check_f0_params(interp, par, sf)){
-    Tcl_AppendResult(interp, "invalid/inconsistent parameters -- exiting.", NULL);
-    return TCL_ERROR;
-  }
-
-  total_samps = endpos - startpos + 1;
-  if(total_samps < ((par->frame_step * 2.0) + par->wind_dur) * sf) {
-    Tcl_AppendResult(interp, "input range too small for analysis by get_f0.", NULL);
-    return TCL_ERROR;
-  }
-  /* Initialize variables in get_f0.c; allocate data structures;
-   * determine length and overlap of input frames to read.
-   */
-  if (init_dp_f0(sf, par, &buff_size, &sdstep)
-      || buff_size > INT_MAX || sdstep > INT_MAX)
-  {
-    Tcl_AppendResult(interp, "problem in init_dp_f0().", NULL);
-    return TCL_ERROR;
-  }
-
-  if (debug_level)
-    Fprintf(stderr, "init_dp_f0 returned buff_size %ld, sdstep %ld.\n",buff_size, sdstep);
-
-  if (buff_size > total_samps)
-    buff_size = total_samps;
-
-  actsize = min(buff_size, sound->length);
-  fdata = (float *) ckalloc(sizeof(float) * max(buff_size, sdstep));
-  list = Tcl_NewListObj(0, NULL);
-  Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", 0.0);
-  ndone = startpos;
-
-  while (TRUE) {
-    done = (actsize < buff_size) || (total_samps == buff_size);
-    Snack_GetSoundData(sound, ndone, fdata, actsize);
-    /*if (sound->debug > 0) Snack_WriteLog("dp_f0...\n");*/
-    if (dp_f0(fdata, (int) actsize, (int) sdstep, sf, par,
-	      &f0p, &vuvp, &rms_speech, &acpkp, &vecsize, done)) {
-      Tcl_AppendResult(interp, "problem in dp_f0().", NULL);
-      return TCL_ERROR;
-    }
-    /*if (sound->debug > 0) Snack_WriteLogInt("done dp_f0",vecsize);*/
-    for (i = vecsize - 1; i >= 0; i--) {
-      Tcl_Obj *frameList;
-      frameList = Tcl_NewListObj(0, NULL);
-      Tcl_ListObjAppendElement(interp, list, frameList);
-      Tcl_ListObjAppendElement(interp, frameList,
-			       Tcl_NewDoubleObj((double)f0p[i]));
-      Tcl_ListObjAppendElement(interp, frameList,
-			       Tcl_NewDoubleObj((double)vuvp[i]));
-      Tcl_ListObjAppendElement(interp, frameList,
-			       Tcl_NewDoubleObj((double)rms_speech[i]));
-      Tcl_ListObjAppendElement(interp, frameList,
-			       Tcl_NewDoubleObj((double)acpkp[i]));
-    }
-
-    if (done) break;
-
-    ndone += sdstep; 
-    actsize = min(buff_size, sound->length - ndone);
-    total_samps -= sdstep;
-
-    if (actsize > total_samps)
-      actsize = total_samps;
-
-    if (1) {
-      int res = Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", (double) ndone / sound->length);
-      if (res != TCL_OK) {
-	return TCL_ERROR;
-      }
-    }
-  }
-
-  Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", 1.0);
-
-  ckfree((void *)fdata);
-
-  ckfree((void *)par);
-
-  free_dp_f0();
-  
-  Tcl_SetObjResult(interp, list);
-
-  return TCL_OK;
-}
-
-#endif
 
 /*
  * Some consistency checks on parameter values.
  * Return a positive integer if any errors detected, 0 if none.
  */
 
-#if 0
-static int
-check_f0_params(Tcl_Interp *interp, F0_params *par, double sample_freq)
-#else
 static int
 check_f0_params(F0_params *par, double sample_freq)
-#endif /* 0 */
 {
   int	  error = 0;
   double  dstep;
 
-#if 0
-  if((par->cand_thresh < 0.01) || (par->cand_thresh > 0.99)) {
-    Tcl_AppendResult(interp,
-	  "ERROR: cand_thresh parameter must be between [0.01, 0.99].",NULL);
-    error++;
-  }
-  if((par->wind_dur > .1) || (par->wind_dur < .0001)) {
-    Tcl_AppendResult(interp,"ERROR: wind_dur parameter must be between [0.0001, 0.1].",NULL);
-    error++;
-  }
-  if((par->n_cands > 100) || (par->n_cands < 3)){
-    Tcl_AppendResult(interp,
-	    "ERROR: n_cands parameter must be between [3,100].",NULL); 
-    error++;
-  }
-#endif /* 0 */
   if((par->max_f0 <= par->min_f0) || (par->max_f0 >= (sample_freq/2.0)) ||
      (par->min_f0 < (sample_freq/10000.0))){
-#if 0
-    Tcl_AppendResult(interp,
-	    "ERROR: min(max)_f0 parameter inconsistent with sampling frequency.",NULL); 
-#else
     fprintf(stderr, "ERROR: min(max)_f0 parameter inconsistent with sampling frequency.\n");
-#endif /* 0 */
     error++;
   }
   dstep = ((double)((int)(0.5 + (sample_freq * par->frame_step))))/sample_freq;
   if(dstep != par->frame_step) {
-#if 0
-    if(debug_level)
-      Tcl_AppendResult(interp,
-	      "Frame step set to exactly match signal sample rate.",NULL);
-#endif /* 0 */
     par->frame_step = (float) dstep;
   }
   if((par->frame_step > 0.1) || (par->frame_step < (1.0/sample_freq))){
-#if 0
-    Tcl_AppendResult(interp,
-	    "ERROR: frame_step parameter must be between [1/sampling rate, 0.1].",NULL); 
-#else
     fprintf(stderr, "ERROR: frame_step parameter must be between [1/sampling rate, 0.1].\n");
-#endif /* 0 */
     error++;
   }
 
@@ -405,7 +134,7 @@ void get_fast_cands(fdata, fdsdata, ind, step, size, dec, start, nlags, engref, 
   decind = (ind * step)/dec;
   decsize = 1 + (size/dec);
   corp = cp->correl;
-    
+
   crossf(fdsdata + decind, decsize, decstart, decnlags, engref, maxloc,
 	maxval, corp);
   cp->maxloc = *maxloc;	/* location of maximum in correlation */
@@ -422,7 +151,7 @@ void get_fast_cands(fdata, fdsdata, ind, step, size, dec, start, nlags, engref, 
     *lp = (*lp * dec) + (int)(0.5+(xp*dec)); /* refined lag */
     *pe = yp*(1.0f - (lag_wt* *lp)); /* refined amplitude */
   }
-  
+
   if(*ncand >= par->n_cands) {	/* need to prune candidates? */
     register int *loc, *locm, lt;
     register float smaxval, *pem;
@@ -493,23 +222,14 @@ float *downsample(input,samsin,state_idx,freq,samsout,decimate, first_time, last
 
       ncoeff = ((int)(freq * .005)) | 1;
       beta = .5f/decimate;
-#if 0
-      foutput = (float*)ckrealloc((void *)foutput, sizeof(float) * nbuff);
-      /*      spsassert(foutput, "Can't allocate foutput in downsample");*/
-#else
       foutput =
           (float *) realloc((void *) foutput, sizeof(float) * nbuff);
-#endif
       for( ; nbuff > 0 ;)
 	foutput[--nbuff] = 0.0;
 
       if( !lc_lin_fir(beta,&ncoeff,b)) {
 	fprintf(stderr,"\nProblems computing interpolation filter\n");
-#if 0
-	ckfree((void *)foutput);
-#else
 	free((void *) foutput);
-#endif /* 0 */
 	return(NULL);
       }
       ncoefft = (ncoeff/2) + 1;
@@ -518,18 +238,13 @@ float *downsample(input,samsin,state_idx,freq,samsout,decimate, first_time, last
     if(first_time) init = 1;
     else if (last_time) init = 2;
     else init = 0;
-    
+
     if(downsamp(input,foutput,samsin,samsout,state_idx,decimate,ncoefft,b,init)) {
       return(foutput);
     } else
       Fprintf(stderr,"Problems in downsamp() in downsample()\n");
-#if 0  /* skip final frame if it is too small */
-  } else
-    Fprintf(stderr,"Bad parameters passed to downsample()\n");
-#else
   }
-#endif
-  
+
   return(NULL);
 }
 
@@ -619,13 +334,8 @@ int idx;
   buf1 = buf;
   if(ncoef > fsize) {/*allocate memory for full coeff. array and filter memory */    fsize = 0;
     i = (ncoef+1)*2;
-#if 0
-    if(!((co = (float *)ckrealloc((void *)co, sizeof(float)*i)) &&
-	 (mem = (float *)ckrealloc((void *)mem, sizeof(float)*i)))) {
-#else
     if (!((co = (float *) realloc((void *) co, sizeof(float) * i))
        && (mem = (float *) realloc((void *) mem, sizeof(float) * i)))) {
-#endif /* 0 */
       fprintf(stderr,"allocation problems in do_fir()\n");
       return;
     }
@@ -633,7 +343,7 @@ int idx;
   }
 
   /* fill 2nd half with data */
-  for(i=ncoef, dp1=mem+ncoef-1; i-- > 0; )  *dp1++ = *buf++;  
+  for(i=ncoef, dp1=mem+ncoef-1; i-- > 0; )  *dp1++ = *buf++;
 
   if(init & 1) {	/* Is the beginning of the signal in buf? */
     /* Copy the half-filter and its mirror image into the coefficient array. */
@@ -662,28 +372,28 @@ int idx;
   k = (ncoef << 1) -1;	/* inner-product loop limit */
 
   if(skip <= 1) {       /* never used */
-/*    *out_samps = i;	
-    for( ; i-- > 0; ) {	
+/*    *out_samps = i;
+    for( ; i-- > 0; ) {
       for(j=k, dp1=mem, dp2=co, dp3=mem+1, sum = 0.0; j-- > 0;
 	  *dp1++ = *dp3++ )
 	sum += *dp2++ * *dp1;
 
-      *--dp1 = *buf++;	
-      *bufo++ = (sum < 0.0)? sum -0.5 : sum +0.5; 
+      *--dp1 = *buf++;
+      *bufo++ = (sum < 0.0)? sum -0.5 : sum +0.5;
     }
-    if(init & 2) {	
+    if(init & 2) {
       for(i=ncoef; i-- > 0; ) {
 	for(j=k, dp1=mem, dp2=co, dp3=mem+1, sum = 0.0; j-- > 0;
 	    *dp1++ = *dp3++ )
 	  sum += *dp2++ * *dp1;
 	*--dp1 = 0.0;
-	*bufo++ = (sum < 0)? sum -0.5 : sum +0.5; 
+	*bufo++ = (sum < 0)? sum -0.5 : sum +0.5;
       }
       *out_samps += ncoef;
     }
     return;
 */
-  } 
+  }
   else {			/* skip points (e.g. for downsampling) */
     /* the buffer end is padded with (ncoef-1) data points */
     for( l=0 ; l < *out_samps; l++ ) {
@@ -736,9 +446,9 @@ int	*nf;
     /* Now apply a Hanning window to the (infinite) impulse response. */
     /* (Probably should use a better window, like Kaiser...) */
     fn = twopi/(double)(*nf);
-    for(i=0;i<n;i++) 
+    for(i=0;i<n;i++)
 	coef[n-i-1] *= (float)((.5 - (.5 * cos(fn * ((double)i + 0.5)))));
-    
+
     return(TRUE);
 }
 
@@ -751,7 +461,7 @@ static void peak(y, xp, yp)
        *xp, *yp;  /* x,y values of parabolic peak fitting the input points. */
 {
   register float a, c;
-  
+
   a = (float)((y[2]-y[1])+(.5*(y[0]-y[2])));
   if(fabs(a) > .000001) {
     *xp = c = (float)((y[0]-y[2])/(4.0*a));
@@ -803,8 +513,8 @@ static void peak(y, xp, yp)
 /*
  * READ_SIZE: length of input data frame in sec to read
  * DP_CIRCULAR: determines the initial size of DP circular buffer in sec
- * DP_HIST: stored frame history in second before checking for common path 
- *      DP_CIRCULAR > READ_SIZE, DP_CIRCULAR at least 2 times of DP_HIST 
+ * DP_HIST: stored frame history in second before checking for common path
+ *      DP_CIRCULAR > READ_SIZE, DP_CIRCULAR at least 2 times of DP_HIST
  * DP_LIMIT: in case no convergence is found, DP frames of DP_LIMIT secs
  *      are kept before output is forced by simply picking the lowest cost
  *      path
@@ -815,7 +525,7 @@ static void peak(y, xp, yp)
 #define DP_HIST 0.5
 #define DP_LIMIT 1.0
 
-/* 
+/*
  * stationarity parameters -
  * STAT_WSIZE: window size in sec used in measuring frame energy/stationarity
  * STAT_AINT: analysis interval in sec in measuring frame energy/stationarity
@@ -824,7 +534,7 @@ static void peak(y, xp, yp)
 #define STAT_AINT 0.020
 
 /*
- * headF points to current frame in the circular buffer, 
+ * headF points to current frame in the circular buffer,
  * tailF points to the frame where tracks start
  * cmpthF points to starting frame of converged path to backtrack
  */
@@ -840,7 +550,7 @@ static int size_cir_buffer,	/* # of frames in circular DP buffer */
            num_active_frames,	/* # of frames from tailF to headF */
            output_buf_size;	/* # of frames allocated to output buffers */
 
-/* 
+/*
  * DP parameters
  */
 static float tcost, tfact_a, tfact_s, frame_int, vbias, fdouble, wdur, ln2,
@@ -851,7 +561,7 @@ static short maxpeaks;
 static int wReuse = 0;  /* number of windows seen before resued */
 static Windstat *windstat = NULL;
 
-static float *f0p = NULL, *vuvp = NULL, *rms_speech = NULL, 
+static float *f0p = NULL, *vuvp = NULL, *rms_speech = NULL,
              *acpkp = NULL, *peaks = NULL;
 static int first_time = 1, pad;
 
@@ -879,12 +589,9 @@ init_dp_f0(freq, par, buffsize, sdstep)
   int nframes;
   int i;
   int stat_wsize, agap, ind, downpatch;
-#if 0
-#else
   float *fgetmem(const int leng);
-#endif
 /*
- * reassigning some constants 
+ * reassigning some constants
  */
 
   tcost = par->trans_cost;
@@ -893,7 +600,7 @@ init_dp_f0(freq, par, buffsize, sdstep)
   vbias = par->voice_bias;
   fdouble = par->double_cost;
   frame_int = par->frame_step;
-  
+
   step = eround(frame_int * freq);
   size = eround(par->wind_dur * freq);
   frame_int = (float)(((float)step)/freq);
@@ -911,15 +618,15 @@ init_dp_f0(freq, par, buffsize, sdstep)
 /*
  * SET UP THE D.P. WEIGHTING FACTORS:
  *      The intent is to make the effectiveness of the various fudge factors
- *      independent of frame rate or sampling frequency.                
+ *      independent of frame rate or sampling frequency.
  */
-  
+
   /* Lag-dependent weighting factor to emphasize early peaks (higher freqs)*/
   lagwt = par->lag_weight/stop;
-  
+
   /* Penalty for a frequency skip in F0 per frame */
   freqwt = par->freq_weight/frame_int;
-  
+
   i = (int) (READ_SIZE *freq);
   if(ncomp >= step) nframes = ((i-ncomp)/step ) + 1;
   else nframes = i / step;
@@ -937,13 +644,13 @@ init_dp_f0(freq, par, buffsize, sdstep)
 
      3) downsampling:
            enough to make filtering possible -- downpatch
- 
+
      So there are nframes whole DP frames, padded with pad points
      to make the last frame F0 computation ok.
 
   */
 
-  /* last point in data frame needs points of 1/2 downsampler filter length 
+  /* last point in data frame needs points of 1/2 downsampler filter length
      long, 0.005 is the filter length used in downsampler */
   downpatch = (((int) (freq * 0.005))+1) / 2;
 
@@ -954,7 +661,7 @@ init_dp_f0(freq, par, buffsize, sdstep)
   pad = downpatch + ((i>ncomp) ? i:ncomp);
   *buffsize = nframes * step + pad;
   *sdstep = nframes * step;
-  
+
   /* Allocate space for the DP storage circularly linked data structure */
 
   size_cir_buffer = (int) (DP_CIRCULAR / frame_int);
@@ -976,12 +683,7 @@ init_dp_f0(freq, par, buffsize, sdstep)
 
   /* Allocate sscratch array to use during backtrack convergence test. */
   if( ! pcands ) {
-#if 0
-    pcands = (int *) ckalloc( par->n_cands * sizeof(int));
-    /*    spsassert(pcands,"can't allocate pathcands");*/
-#else
     pcands = (int *) malloc(par->n_cands * sizeof(int));
-#endif /* 0 */
   }
 
   /* Allocate arrays to return F0 and related signals. */
@@ -989,28 +691,6 @@ init_dp_f0(freq, par, buffsize, sdstep)
   /* Note: remember to compare *vecsize with size_frame_out, because
      size_cir_buffer is not constant */
   output_buf_size = size_cir_buffer;
-#if 0
-  rms_speech = (float*)ckalloc(sizeof(float) * output_buf_size);
-  /*  spsassert(rms_speech,"rms_speech ckalloc failed");*/
-  f0p = (float*)ckalloc(sizeof(float) * output_buf_size);
-  /*  spsassert(f0p,"f0p ckalloc failed");*/
-  vuvp = (float*)ckalloc(sizeof(float)* output_buf_size);
-  /*  spsassert(vuvp,"vuvp ckalloc failed");*/
-  acpkp = (float*)ckalloc(sizeof(float) * output_buf_size);
-  /*  spsassert(acpkp,"acpkp ckalloc failed");*/
-
-  /* Allocate space for peak location and amplitude scratch arrays. */
-  peaks = (float*)ckalloc(sizeof(float) * maxpeaks);
-  /*  spsassert(peaks,"peaks ckalloc failed");*/
-  locs = (int*)ckalloc(sizeof(int) * maxpeaks);
-  /*  spsassert(locs, "locs ckalloc failed");*/
-  
-  /* Initialise the retrieval/saving scheme of window statistic measures */
-  wReuse = agap / step;
-  if (wReuse){
-      windstat = (Windstat *) ckalloc( wReuse * sizeof(Windstat));
-      /*      spsassert(windstat, "windstat ckalloc failed");*/
-#else
     rms_speech = (float *) fgetmem(output_buf_size);
     f0p = (float *) fgetmem(output_buf_size);
     vuvp = (float *) fgetmem(output_buf_size);
@@ -1024,7 +704,6 @@ init_dp_f0(freq, par, buffsize, sdstep)
     wReuse = agap / step;
     if (wReuse) {
       windstat = (Windstat *) malloc(wReuse * sizeof(Windstat));
-#endif /* 0 */
       for(i=0; i<wReuse; i++){
 	  windstat[i].err = 0;
 	  windstat[i].rms = 0;
@@ -1080,9 +759,9 @@ dp_f0(fdata, buff_size, sdstep, freq,
     samsds = ((nframes-1) * step + ncomp) / decimate;
 #if 1 /* skip final frame if it is too small */
     if(samsds < 1)
-      return 1; 
+      return 1;
 #endif
-    dsdata = downsample(fdata, buff_size, sdstep, freq, &samsds, decimate, 
+    dsdata = downsample(fdata, buff_size, sdstep, freq, &samsds, decimate,
 			first_time, last_time);
     if (!dsdata) {
       Fprintf(stderr, "can't get downsampled data.\n");
@@ -1093,7 +772,7 @@ dp_f0(fdata, buff_size, sdstep, freq,
   /* Get a function of the "stationarity" of the speech signal. */
 
   stat = get_stationarity(fdata, freq, buff_size, nframes, step, first_time);
-  if (!stat) { 
+  if (!stat) {
     Fprintf(stderr, "can't get stationarity\n");
     return(1);
   }
@@ -1106,7 +785,7 @@ dp_f0(fdata, buff_size, sdstep, freq,
   if(!first_time && nframes > 0) headF = headF->next;
 
   for(i = 0; i < nframes; i++) {
- 
+
     /* NOTE: This buffer growth provision is probably not necessary.
        It was put in (with errors) by Derek Lin and apparently never
        tested.  My tests and analysis suggest it is completely
@@ -1120,7 +799,7 @@ dp_f0(fdata, buff_size, sdstep, freq,
 		"too many requests (%d) for dynamically allocating space.\n   There may be a problem in finding converged path.\n",cir_buff_growth_count);
 	return(1);
       }
-      if(debug_level) 
+      if(debug_level)
 	Fprintf(stderr, "allocating %d more frames for DP circ. buffer.\n", size_cir_buffer);
       frm = alloc_frame(nlags, par->n_cands);
       headF->next = frm;
@@ -1139,13 +818,13 @@ dp_f0(fdata, buff_size, sdstep, freq,
     get_fast_cands(fdata, dsdata, i, step, size, decimate, start,
 		   nlags, &engref, &maxloc,
 		   &maxval, headF->cp, peaks, locs, &ncand, par);
-    
+
     /*    Move the peak value and location arrays into the dp structure */
     {
       register float *ftp1, *ftp2;
       register short *sp1;
       register int *sp2;
-      
+
       for(ftp1 = headF->dp->pvals, ftp2 = peaks,
 	  sp1 = headF->dp->locs, sp2 = locs, j=ncand; j--; ) {
 	*ftp1++ = *ftp2++;
@@ -1200,7 +879,7 @@ dp_f0(fdata, buff_size, sdstep, freq,
 	}
       } else {			/* this is the unvoiced candidate */
 	for(j=0; j<ncandp; j++){ /* for each PREVIOUS candidate... */
-	  
+
 	  /*    Get voicing transition cost. */
 	  if (headF->prev->dp->locs[j] > 0) { /* previous was voiced */
 	    ferr = tcost + (tfact_s * sta[i]) + (tfact_a * rms_ratio[i]);
@@ -1227,12 +906,12 @@ dp_f0(fdata, buff_size, sdstep, freq,
 
     if (i < nframes - 1)
       headF = headF->next;
-    
+
     if (debug_level >= 2) {
       Fprintf(stderr,"%d engref:%10.0f max:%7.5f loc:%4d\n",
 	      i,engref,maxval,maxloc);
     }
-    
+
   } /* end for (i ...) */
 
   /***************************************************************/
@@ -1248,11 +927,11 @@ dp_f0(fdata, buff_size, sdstep, freq,
     Frame *frm;
     int  num_paths, best_cand, frmcnt, checkpath_done = 1;
     float patherrmin;
-      
+
     if(debug_level)
       Fprintf(stderr, "available frames for backtracking: %d\n",
 num_active_frames);
-      
+
     patherrmin = FLT_MAX;
     best_cand = 0;
     num_paths = headF->dp->ncands;
@@ -1321,18 +1000,6 @@ num_active_frames);
 	  Fprintf(stderr,
 		  "reallocating space for output frames: %d\n",
 		  output_buf_size);
-#if 0
-	rms_speech = (float *) ckrealloc((void *) rms_speech,
-				       sizeof(float) * output_buf_size);
-	/*	spsassert(rms_speech, "rms_speech realloc failed in dp_f0()");*/
-	f0p = (float *) ckrealloc((void *) f0p,
-				sizeof(float) * output_buf_size);
-	/*	spsassert(f0p, "f0p realloc failed in dp_f0()");*/
-	vuvp = (float *) ckrealloc((void *) vuvp, sizeof(float) * output_buf_size);
-	/*	spsassert(vuvp, "vuvp realloc failed in dp_f0()");*/
-	acpkp = (float *) ckrealloc((void *) acpkp, sizeof(float) * output_buf_size);
-	/*	spsassert(acpkp, "acpkp realloc failed in dp_f0()");*/
-#else
     rms_speech = (float *)
         realloc((void *) rms_speech,
                 sizeof(float) * output_buf_size);
@@ -1344,8 +1011,6 @@ num_active_frames);
     acpkp =
         (float *) realloc((void *) acpkp,
                           sizeof(float) * output_buf_size);
-#endif /* 0 */
-
       }
       rms_speech[i] = frm->rms;
       acpkp[i] =  frm->dp->pvals[best_cand];
@@ -1356,17 +1021,17 @@ num_active_frames);
       if(loc1 > 0) {		/* Was f0 actually estimated for this frame? */
 	if (loc1 > start && loc1 < stop) { /* loc1 must be a local maximum. */
 	  float cormax, cprev, cnext, den;
-		  
+
 	  j = loc1 - start;
 	  cormax = frm->cp->correl[j];
 	  cprev = frm->cp->correl[j+1];
 	  cnext = frm->cp->correl[j-1];
 	  den = (float) (2.0 * ( cprev + cnext - (2.0 * cormax) ));
 	  /*
-	   * Only parabolic interpolate if cormax is indeed a local 
+	   * Only parabolic interpolate if cormax is indeed a local
 	   * turning point. Find peak of curve that goes though the 3 points
 	   */
-		  
+
 	  if (fabs(den) > 0.000001)
 	    ftemp += 2.0f - ((((5.0f*cprev)+(3.0f*cnext)-(8.0f*cormax))/den));
 	}
@@ -1376,10 +1041,10 @@ num_active_frames);
 	vuvp[i] = 0.0;
       }
       frm = frm->prev;
-	  
+
       if (debug_level >= 2)
 	Fprintf(stderr," i:%4d%8.1f%8.1f\n",i,f0p[i],vuvp[i]);
-      /* f0p[i] starts from the most recent one */ 
+      /* f0p[i] starts from the most recent one */
       /* Need to reverse the order in the calling function */
       i++;
     } /* end while() */
@@ -1392,13 +1057,13 @@ num_active_frames);
 
   if (debug_level)
     Fprintf(stderr, "writing out %d frames.\n", *vecsize);
-  
+
   *f0p_pt = f0p;
   *vuvp_pt = vuvp;
   *acpkp_pt = acpkp;
   *rms_speech_pt = rms_speech;
   /*  *acpkp_pt = acpkp;*/
-  
+
   if(first_time) first_time = 0;
   return(0);
 }
@@ -1412,27 +1077,6 @@ alloc_frame(nlags, ncands)
   Frame *frm;
   int j;
 
-#if 0
-  frm = (Frame*)ckalloc(sizeof(Frame));
-  frm->dp = (Dprec *) ckalloc(sizeof(Dprec));
-  /*  spsassert(frm->dp,"frm->dp ckalloc failed in alloc_frame");*/
-  frm->dp->ncands = 0;
-  frm->cp = (Cross *) ckalloc(sizeof(Cross));
-  /*  spsassert(frm->cp,"frm->cp ckalloc failed in alloc_frame");*/
-  frm->cp->correl = (float *) ckalloc(sizeof(float) * nlags);
-  /*  spsassert(frm->cp->correl, "frm->cp->correl ckalloc failed");*/
-  /* Allocate space for candidates and working arrays. */
-  frm->dp->locs = (short*)ckalloc(sizeof(short) * ncands);
-  /*  spsassert(frm->dp->locs,"frm->dp->locs ckalloc failed in alloc_frame()");*/
-  frm->dp->pvals = (float*)ckalloc(sizeof(float) * ncands);
-/*  spsassert(frm->dp->pvals,"frm->dp->pvals ckalloc failed in alloc_frame()");*/
-  frm->dp->mpvals = (float*)ckalloc(sizeof(float) * ncands);
-  /*  spsassert(frm->dp->mpvals,"frm->dp->mpvals ckalloc failed in alloc_frame()");*/
-  frm->dp->prept = (short*)ckalloc(sizeof(short) * ncands);
-  /*  spsassert(frm->dp->prept,"frm->dp->prept ckalloc failed in alloc_frame()");*/
-  frm->dp->dpvals = (float*)ckalloc(sizeof(float) * ncands);
-  /*  spsassert(frm->dp->dpvals,"frm->dp->dpvals ckalloc failed in alloc_frame()");*/
-#else
   frm = (Frame *) malloc(sizeof(Frame));
   frm->dp = (Dprec *) malloc(sizeof(Dprec));
   frm->dp->ncands = 0;
@@ -1443,8 +1087,7 @@ alloc_frame(nlags, ncands)
   frm->dp->mpvals = (float *) malloc(sizeof(float) * ncands);
   frm->dp->prept = (short *) malloc(sizeof(short) * ncands);
   frm->dp->dpvals = (float *) malloc(sizeof(float) * ncands);
-#endif /* 0 */
-    
+
   /*  Initialize the cumulative DP costs to zero */
   for(j = ncands-1; j >= 0; j--)
     frm->dp->dpvals[j] = 0.0;
@@ -1480,7 +1123,7 @@ save_windstat(rho, order, err, rms)
 	windstat[0].err = (float) err;
 	windstat[0].rms = (float) rms;
 	return 1;
-    } else 
+    } else
 	return 0;
 }
 
@@ -1495,7 +1138,7 @@ retrieve_windstat(rho, order, err, rms)
 {
     Windstat wstat;
     int i;
-	
+
     if(wReuse){
 	wstat = windstat[0];
 	for(i=0; i<=order; i++) rho[i] = wstat.rho[i];
@@ -1516,7 +1159,7 @@ get_similarity(order, size, pdata, cdata,
     float   *rmsa, *rms_ratio, pre, stab;
     int     w_type, init;
 {
-  float rho3[BIGSORD+1], err3, rms3, rmsd3, b0, t, a2[BIGSORD+1], 
+  float rho3[BIGSORD+1], err3, rms3, rmsd3, b0, t, a2[BIGSORD+1],
       rho1[BIGSORD+1], a1[BIGSORD+1], b[BIGSORD+1], err1, rms1, rmsd1;
   float xitakura(), wind_energy();
   void xa_to_aca ();
@@ -1531,7 +1174,7 @@ get_similarity(order, size, pdata, cdata,
   xlpc(order, stab, size-1, cdata,
       a2, rho3, (float *) NULL, &err3, &rmsd3, pre, w_type);
   rms3 = wind_energy(cdata, size, w_type);
-  
+
   if(!init) {
       /* get previous window stat */
       if( !retrieve_windstat(rho1, order, &err1, &rms1)){
@@ -1562,7 +1205,7 @@ get_similarity(order, size, pdata, cdata,
 /* This is an ad hoc signal stationarity function based on Itakura
  * distance and relative amplitudes.
  */
-/* 
+/*
   This illustrates the window locations when the very first frame is read.
   It shows an example where each frame step |  .  | is 10 msec.  The
   frame step size is variable.  The window size is always 30 msec.
@@ -1586,7 +1229,7 @@ get_similarity(order, size, pdata, cdata,
                           ind
 
   fdata, q, p, ind, are variables used below.
-   
+
 */
 
 static Stat *stat = NULL;
@@ -1610,43 +1253,22 @@ get_stationarity(fdata, freq, buff_size, nframes, frame_step, first_time)
   if( nframes_old < nframes || !stat || first_time){
     /* move this to init_dp_f0() later */
     nframes_old = nframes;
-#if 0
-    if(stat){
-      ckfree((char *) stat->stat);
-      ckfree((char *) stat->rms);
-      ckfree((char *) stat->rms_ratio);
-      ckfree((char *) stat);
-    }
-    if (mem) ckfree((void *)mem); 
-    stat = (Stat *) ckalloc(sizeof(Stat));
-    /*    spsassert(stat,"stat ckalloc failed in get_stationarity");*/
-    stat->stat = (float*)ckalloc(sizeof(float)*nframes);
-    /*    spsassert(stat->stat,"stat->stat ckalloc failed in get_stationarity");*/
-    stat->rms = (float*)ckalloc(sizeof(float)*nframes);
-    /*    spsassert(stat->rms,"stat->rms ckalloc failed in get_stationarity");*/
-    stat->rms_ratio = (float*)ckalloc(sizeof(float)*nframes);
-    /*    spsassert(stat->rms_ratio,"stat->ratio ckalloc failed in get_stationarity");*/
-    memsize = (int) (STAT_WSIZE * freq) + (int) (STAT_AINT * freq);
-    mem = (float *) ckalloc( sizeof(float) * memsize);
-    /*    spsassert(mem, "mem ckalloc failed in get_stationarity()");*/
-#else
     if(stat){
         free((char *) stat->stat);
         free((char *) stat->rms);
         free((char *) stat->rms_ratio);
         free((char *) stat);
     }
-    if (mem) free((void *) mem); 
+    if (mem) free((void *) mem);
     stat = (Stat *) malloc(sizeof(Stat));
     stat->stat = (float *) malloc(sizeof(float) * nframes);
     stat->rms = (float *) malloc(sizeof(float) * nframes);
     stat->rms_ratio = (float *) malloc(sizeof(float) * nframes);
     memsize = (int) (STAT_WSIZE * freq) + (int) (STAT_AINT * freq);
     mem = (float *) malloc(sizeof(float) * memsize);
-#endif /* 0 */
     for(j=0; j<memsize; j++) mem[j] = 0;
   }
-  
+
   if(nframes == 0) return(stat);
 
   q = fdata + ind;
@@ -1665,7 +1287,7 @@ get_stationarity(fdata, freq, buff_size, nframes, frame_step, first_time)
 
   for(j=0, p = q - agap; j < nframes; j++, p += frame_step, q += frame_step){
       if( (p >= fdata) && (q >= fdata) && ( q + size <= datend) )
-	  stat->stat[j] = get_similarity(order,size, p, q, 
+	  stat->stat[j] = get_similarity(order,size, p, q,
 					     &(stat->rms[j]),
 					     &(stat->rms_ratio[j]),preemp,
 					     stab,w_type, 0);
@@ -1683,17 +1305,17 @@ get_stationarity(fdata, freq, buff_size, nframes, frame_step, first_time)
 	      }
 	  } else {
 	      if( (p<fdata) && (q+size <=datend) ){
-		  stat->stat[j] = get_similarity(order,size, mem, 
+		  stat->stat[j] = get_similarity(order,size, mem,
 						     mem + (memsize/2) + ind,
 						     &(stat->rms[j]),
 						     &(stat->rms_ratio[j]),
 						     preemp, stab,w_type, 0);
 		  /* prepare for the next frame_step if needed */
 		  if(p + frame_step < fdata ){
-		      for( m=0; m<(memsize-frame_step); m++) 
+		      for( m=0; m<(memsize-frame_step); m++)
 			  mem[m] = mem[m+frame_step];
 		      r = q + size;
-		      for( m=0; m<frame_step; m++) 
+		      for( m=0; m<frame_step; m++)
 			  mem[memsize-frame_step+m] = *r++;
 		  }
 	      }
@@ -1708,19 +1330,6 @@ get_stationarity(fdata, freq, buff_size, nframes, frame_step, first_time)
 }
 
 
-#if 0
-/* -------------------------------------------------------------------- */
-/*	Round the argument to the nearest integer.			*/
-/*
-int
-eround(flnum)
-    double  flnum;
-{
-  return((flnum >= 0.0) ? (int)(flnum + 0.5) : (int)(flnum - 0.5));
-}
-
-*/
-#else
 /* -------------------------------------------------------------------- */
 /*	Round the argument to the nearest integer.			*/
 
@@ -1731,68 +1340,10 @@ eround(flnum)
   return((flnum >= 0.0) ? (int)(flnum + 0.5) : (int)(flnum - 0.5));
 }
 
-#endif /* 0 */
-
-void free_dp_f0()
+static void free_dp_f0()
 {
   int i;
   Frame *frm, *next;
-#if 0
-  
-  ckfree((void *)pcands);
-  pcands = NULL;
-  
-  ckfree((void *)rms_speech);
-  rms_speech = NULL;
-  
-  ckfree((void *)f0p);
-  f0p = NULL;
-  
-  ckfree((void *)vuvp);
-  vuvp = NULL;
-  
-  ckfree((void *)acpkp);
-  acpkp = NULL;
-  
-  ckfree((void *)peaks);
-  peaks = NULL;
-  
-  ckfree((void *)locs);
-  locs = NULL;
-  
-  if (wReuse) {
-    ckfree((void *)windstat);
-    windstat = NULL;
-  }
-  
-  frm = headF;
-  
-  for(i = 0; i < size_cir_buffer; i++) {
-    next = frm->next;
-    ckfree((void *)frm->cp->correl);
-    ckfree((void *)frm->dp->locs);
-    ckfree((void *)frm->dp->pvals);
-    ckfree((void *)frm->dp->mpvals);
-    ckfree((void *)frm->dp->prept);
-    ckfree((void *)frm->dp->dpvals);
-    ckfree((void *)frm->cp);
-    ckfree((void *)frm->dp);
-    ckfree((void *)frm);
-    frm = next;
-  }
-  headF = NULL;
-  tailF = NULL;
-  
-  ckfree((void *)stat->stat);
-  ckfree((void *)stat->rms);
-  ckfree((void *)stat->rms_ratio);
-
-  ckfree((void *)stat);
-  stat = NULL;
-
-  ckfree((void *)mem);
-  mem = NULL;
-#else
     free((void *) pcands);
     pcands = NULL;
 
@@ -1846,19 +1397,11 @@ void free_dp_f0()
 
     free((void *) mem);
     mem = NULL;
-#endif /* 0 */
-
 }
 
-#if 0
-int
-cGet_f0(Sound *sound, Tcl_Interp *interp, float **outlist, int *length)
-{
-#else
 void rapt(float_list *input, int length, double sample_freq, int frame_shift, double minF0, double maxF0, double voice_bias, int otype)
 {
   int fnum = 0;
-#endif
   float *fdata;
   int done;
   long buff_size, actsize;
@@ -1870,12 +1413,6 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
   static int framestep = -1;
   long sdstep = 0, total_samps;
   int ndone = 0;
-#if 0
-  Tcl_Obj *list;
-  float *tmp = (float *)ckalloc(sizeof(float) * (5 + sound->length / 80));
-  int count = 0;
-  int startpos = 0, endpos = -1;
-#else
   float *tmp, *unvoiced, *buf;
   int count = 0;
   int startpos = 0, endpos = -1;
@@ -1885,16 +1422,6 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
   double p, fsp, alpha, beta;
   unsigned long next = 1;
   double nrandom(unsigned long *next);
-#endif /* 0 */
-
-#if 0
-  if (sound->cmdPtr != NULL) {
-    Tcl_DecrRefCount(sound->cmdPtr);
-    sound->cmdPtr = NULL;
-  }
-
-  par = (F0_params *) ckalloc(sizeof(F0_params));
-#else
 
   for (i = 0, tmpf = input; tmpf != NULL; i++, tmpf = tmpf->next) {
       p = (double) nrandom(&next);
@@ -1929,7 +1456,6 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
   for (i = 0, tmpf = input; tmpf != NULL; i++, tmpf = tmpf->next) {
       buf[i] = tmpf->f;
   }
-#endif /* 0 */
   par->cand_thresh = 0.3f;
   par->lag_weight = 0.3f;
   par->freq_weight = 0.02f;
@@ -1938,58 +1464,16 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
   par->trans_spec = 0.5f;
   par->voice_bias = 0.0f;
   par->double_cost = 0.35f;
-#if 0
-  par->min_f0 = 50;
-  par->max_f0 = 550;
-  par->frame_step = 0.01f;
-#else
   par->min_f0 = minF0;
   par->max_f0 = maxF0;
   par->frame_step = frame_shift / sample_freq;
-#endif
   par->wind_dur = 0.0075f;
   par->n_cands = 20;
   par->mean_f0 = 200;          /* unused */
   par->mean_f0_weight = 0.0f;  /* unused */
   par->conditioning = 0;       /* unused */
-#if 1
   par->voice_bias = voice_bias; /* overwrite U/V threshold for pitch command */
-#endif
 
-#if 0
-  if (startpos < 0) startpos = 0;
-  if (endpos >= (sound->length - 1) || endpos == -1)
-    endpos = sound->length - 1;
-  if (startpos > endpos) return TCL_OK;
-
-  sf = (double) sound->samprate;
-
-  if (framestep > 0)  /* If a value was specified with -S, use it. */
-    par->frame_step = (float) (framestep / sf);
-  start_time = 0.0f;
-  if(check_f0_params(interp, par, sf)){
-    Tcl_AppendResult(interp, "invalid/inconsistent parameters -- exiting.", NULL);
-    return TCL_ERROR;
-  }
-
-  total_samps = endpos - startpos + 1;
-  if(total_samps < ((par->frame_step * 2.0) + par->wind_dur) * sf) {
-    Tcl_AppendResult(interp, "input range too small for analysis by get_f0.", NULL);
-    return TCL_ERROR;
-  }
-  /* Initialize variables in get_f0.c; allocate data structures;
-   * determine length and overlap of input frames to read.
-   */
-  if (init_dp_f0(sf, par, &buff_size, &sdstep)
-      || buff_size > INT_MAX || sdstep > INT_MAX)
-  {
-    Tcl_AppendResult(interp, "problem in init_dp_f0().", NULL);
-    return TCL_ERROR;
-  }
-
-  if (debug_level)
-    Fprintf(stderr, "init_dp_f0 returned buff_size %ld, sdstep %ld.\n",buff_size, sdstep);
-#else
     if (startpos < 0) startpos = 0;
     if (endpos >= (length - 1) || endpos == -1) {
         endpos = length - 1;
@@ -2001,67 +1485,32 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
     start_time = 0.0f;
 
     if (check_f0_params(par, sf)) {
-#endif /* 0 */
-#if 0
-       return "invalid/inconsistent parameters -- exiting.";
-#else
        fprintf(stderr, "invalid/inconsistent parameters -- exiting.\n");
        usage(1);
-#endif
     }
 
     total_samps = endpos - startpos + 1;
 
     if (total_samps < ((par->frame_step * 2.0) + par->wind_dur) * sf) {
-#if 0
-        return "input range too small for analysis by get_f0.";
-#else
        fprintf(stderr, "input range too small for analysis by get_f0.\n");
        usage(1);
-#endif
     }
 
     if (init_dp_f0(sf, par, &buff_size, &sdstep)
         || buff_size > INT_MAX || sdstep > INT_MAX) {
-#if 0
-        return "problem in init_dp_f0().";
-#else
        fprintf(stderr, "problem in init_dp_f0().\n");
        usage(1);
     }
-#endif /* 0 */
 
   if (buff_size > total_samps)
     buff_size = total_samps;
 
-#if 0
-  actsize = min(buff_size, sound->length);
-  fdata = (float *) ckalloc(sizeof(float) * max(buff_size, sdstep));
-  list = Tcl_NewListObj(0, NULL);
-#else
   max = buff_size > sdstep ? buff_size : sdstep;
   actsize = buff_size < length ? buff_size : length;
   fdata = (float *) malloc(sizeof(float) * max);
-#endif /* 0 */
   /*  Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", 0.0);*/
   ndone = startpos;
 
-#if 0
-  while (TRUE) {
-    done = (actsize < buff_size) || (total_samps == buff_size);
-    Snack_GetSoundData(sound, ndone, fdata, actsize);
-    /*if (sound->debug > 0) Snack_WriteLog("dp_f0...\n");*/
-    if (dp_f0(fdata, (int) actsize, (int) sdstep, sf, par,
-	      &f0p, &vuvp, &rms_speech, &acpkp, &vecsize, done)) {
-      Tcl_AppendResult(interp, "problem in dp_f0().", NULL);
-      return TCL_ERROR;
-    }
-    /*if (sound->debug > 0) Snack_WriteLogInt("done dp_f0",vecsize);*/
-    for (i = vecsize - 1; i >= 0; i--) {
-      tmp[count] = f0p[i];
-      count++;
-    }
-#else
     while (1) {
         done = (actsize < buff_size) || (total_samps == buff_size);
         for (i = 0; i < actsize; i++) {
@@ -2069,12 +1518,7 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
         }
         if (dp_f0(fdata, (int) actsize, (int) sdstep, sf, par,
                   &f0p, &vuvp, &rms_speech, &acpkp, &vecsize, done)) {
-#endif
-#if 0
-            return "problem in dp_f0().";
-#else
             break;  /* skip final frame if it is too small */
-#endif /* 0 */
         }
 
         for (i = vecsize - 1; i >= 0; i--) {
@@ -2086,13 +1530,9 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
 
     if (done) break;
 
-    ndone += sdstep; 
-#if 0
-    actsize = min(buff_size, sound->length - ndone);
-#else
+    ndone += sdstep;
     actsize = buff_size < (length - ndone)
         ? buff_size : (length - ndone);
-#endif /* 0 */
     total_samps -= sdstep;
 
     if (actsize > total_samps)
@@ -2108,19 +1548,6 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
 
   /*Snack_ProgressCallback(sound->cmdPtr, interp, "Computing pitch", 1.0);*/
 
-#if 0
-  ckfree((void *)fdata);
-
-  ckfree((void *)par);
-
-  free_dp_f0();
-
-  *outlist = tmp;
-  *length = count;  
-  /*Tcl_SetObjResult(interp, list);*/
-
-  return TCL_OK;
-#else
   for (i = 0; i < fnum; i++) {
       switch (otype) {
       case 1:                   /* f0 */
@@ -2148,6 +1575,4 @@ void rapt(float_list *input, int length, double sample_freq, int frame_shift, do
   free((void *) par);
 
   free_dp_f0();
-
-#endif /* 0 */
 }

--- a/bin/pitch/snack/jkGetF0.h
+++ b/bin/pitch/snack/jkGetF0.h
@@ -154,13 +154,16 @@ typedef struct frame_rec{
 
 extern   Frame *alloc_frame();
 
-typedef struct _float_list {
-    float f;
-    struct _float_list *next;
-} float_list;
+/****************************************************************
+    The RAPT pitch tracker
 
-/* The RAPT interface */
-void rapt(float_list *input, int length, double sample_freq, int frame_shift,
-     double minF0, double maxF0, double voice_bias, int otype);
+        return   value :    0 -> completed normally
+                            1 -> invalid/inconsistent parameters
+                            2 -> input range too small
+                            3 -> problem in init_dp_f0
+
+*****************************************************************/
+int rapt(float *input, float* output, int length, double sample_freq,
+     int frame_shift, double minF0, double maxF0, double voice_bias, int otype);
 
 #endif  /* JK_GET_F0_H_ */

--- a/bin/pitch/snack/jkGetF0.h
+++ b/bin/pitch/snack/jkGetF0.h
@@ -3,7 +3,7 @@
  * by Microsoft Corp. with the terms in the accompanying file BSD.txt,
  * which is a BSD style license.
  *
- *    "Copyright (c) 1990-1996 Entropic Research Laboratory, Inc. 
+ *    "Copyright (c) 1990-1996 Entropic Research Laboratory, Inc.
  *                   All rights reserved"
  *
  * Written by:  David Talkin
@@ -62,7 +62,7 @@
 
 /* f0.h */
 /* Some definitions used by the "Pitch Tracker Software". */
-       
+
 typedef struct f0_params {
 float cand_thresh,	/* only correlation peaks above this are considered */
       lag_weight,	/* degree to which shorter lags are weighted */
@@ -151,3 +151,12 @@ typedef struct frame_rec{
 } Frame;
 
 extern   Frame *alloc_frame();
+
+typedef struct _float_list {
+    float f;
+    struct _float_list *next;
+} float_list;
+
+/* The RAPT interface */
+void rapt(float_list *input, int length, double sample_freq, int frame_shift,
+     double minF0, double maxF0, double voice_bias, int otype);

--- a/bin/pitch/snack/jkGetF0.h
+++ b/bin/pitch/snack/jkGetF0.h
@@ -62,89 +62,81 @@
 #ifndef JK_GET_F0_H_
 #define JK_GET_F0_H_
 
+#include "sigproc.h"
+
 /* f0.h */
 /* Some definitions used by the "Pitch Tracker Software". */
 
 typedef struct f0_params {
-float cand_thresh,	/* only correlation peaks above this are considered */
-      lag_weight,	/* degree to which shorter lags are weighted */
-      freq_weight,	/* weighting given to F0 trajectory smoothness */
-      trans_cost,	/* fixed cost for a voicing-state transition */
-      trans_amp,	/* amplitude-change-modulated VUV trans. cost */
-      trans_spec,	/* spectral-change-modulated VUV trans. cost */
-      voice_bias,	/* fixed bias towards the voiced hypothesis */
-      double_cost,	/* cost for octave F0 jumps */
-      mean_f0,		/* talker-specific mean F0 (Hz) */
-      mean_f0_weight,	/* weight to be given to deviations from mean F0 */
-      min_f0,		/* min. F0 to search for (Hz) */
-      max_f0,		/* max. F0 to search for (Hz) */
-      frame_step,	/* inter-frame-interval (sec) */
-      wind_dur;		/* duration of correlation window (sec) */
-int   n_cands,		/* max. # of F0 cands. to consider at each frame */
-      conditioning;     /* Specify optional signal pre-conditioning. */
+  float cand_thresh,  /* only correlation peaks above this are considered */
+      lag_weight,     /* degree to which shorter lags are weighted */
+      freq_weight,    /* weighting given to F0 trajectory smoothness */
+      trans_cost,     /* fixed cost for a voicing-state transition */
+      trans_amp,      /* amplitude-change-modulated VUV trans. cost */
+      trans_spec,     /* spectral-change-modulated VUV trans. cost */
+      voice_bias,     /* fixed bias towards the voiced hypothesis */
+      double_cost,    /* cost for octave F0 jumps */
+      mean_f0,        /* talker-specific mean F0 (Hz) */
+      mean_f0_weight, /* weight to be given to deviations from mean F0 */
+      min_f0,         /* min. F0 to search for (Hz) */
+      max_f0,         /* max. F0 to search for (Hz) */
+      frame_step,     /* inter-frame-interval (sec) */
+      wind_dur;       /* duration of correlation window (sec) */
+  int n_cands,        /* max. # of F0 cands. to consider at each frame */
+      conditioning;   /* Specify optional signal pre-conditioning. */
 } F0_params;
 
 /* Possible values returned by the function f0(). */
-#define F0_OK		0
-#define F0_NO_RETURNS	1
-#define F0_TOO_FEW_SAMPLES	2
-#define F0_NO_INPUT	3
-#define F0_NO_PAR	4
-#define F0_BAD_PAR	5
-#define F0_BAD_INPUT	6
-#define F0_INTERNAL_ERR	7
+#define F0_OK 0
+#define F0_NO_RETURNS 1
+#define F0_TOO_FEW_SAMPLES 2
+#define F0_NO_INPUT 3
+#define F0_NO_PAR 4
+#define F0_BAD_PAR 5
+#define F0_BAD_INPUT 6
+#define F0_INTERNAL_ERR 7
 
 /* Bits to specify optional pre-conditioning of speech signals by f0() */
 /* These may be OR'ed together to specify all preprocessing. */
-#define F0_PC_NONE	0x00		/* no pre-processing */
-#define F0_PC_DC	0x01		/* remove DC */
-#define F0_PC_LP2000	0x02		/* 2000 Hz lowpass */
-#define F0_PC_HP100	0x04		/* 100 Hz highpass */
-#define F0_PC_AR	0x08		/* inf_order-order LPC inverse filter */
-#define F0_PC_DIFF	0x010		/* 1st-order difference */
-
-extern F0_params *new_f0_params();
-extern int atoi(), eround(), lpc(), window(), get_window();
-extern void get_fast_cands(), a_to_aca(), cross(), crossf(), crossfi(),
-           autoc(), durbin();
-
-#define Fprintf (void)fprintf
+#define F0_PC_NONE 0x00   /* no pre-processing */
+#define F0_PC_DC 0x01     /* remove DC */
+#define F0_PC_LP2000 0x02 /* 2000 Hz lowpass */
+#define F0_PC_HP100 0x04  /* 100 Hz highpass */
+#define F0_PC_AR 0x08     /* inf_order-order LPC inverse filter */
+#define F0_PC_DIFF 0x010  /* 1st-order difference */
 
 /* f0_structs.h */
 
-#define BIGSORD 100
-
-typedef struct cross_rec { /* for storing the crosscorrelation information */
-	float	rms;	/* rms energy in the reference window */
-	float	maxval;	/* max in the crosscorr. fun. q15 */
-	short	maxloc; /* lag # at which max occured	*/
-	short	firstlag; /* the first non-zero lag computed */
-	float	*correl; /* the normalized corsscor. fun. q15 */
+typedef struct cross_rec {/* for storing the crosscorrelation information */
+  float rms;              /* rms energy in the reference window */
+  float maxval;           /* max in the crosscorr. fun. q15 */
+  short maxloc;           /* lag # at which max occured	*/
+  short firstlag;         /* the first non-zero lag computed */
+  float *correl;          /* the normalized corsscor. fun. q15 */
 } Cross;
 
-typedef struct dp_rec { /* for storing the DP information */
-	short	ncands;	/* # of candidate pitch intervals in the frame */
-	short	*locs; /* locations of the candidates */
-	float	*pvals; /* peak values of the candidates */
-	float	*mpvals; /* modified peak values of the candidates */
-	short	*prept; /* pointers to best previous cands. */
-	float	*dpvals; /* cumulative error for each candidate */
+typedef struct dp_rec {/* for storing the DP information */
+  short ncands;        /* # of candidate pitch intervals in the frame */
+  short *locs;         /* locations of the candidates */
+  float *pvals;        /* peak values of the candidates */
+  float *mpvals;       /* modified peak values of the candidates */
+  short *prept;        /* pointers to best previous cands. */
+  float *dpvals;       /* cumulative error for each candidate */
 } Dprec;
 
-typedef struct windstat_rec {  /* for lpc stat measure in a window */
-    float rho[BIGSORD+1];
-    float err;
-    float rms;
+typedef struct windstat_rec {/* for lpc stat measure in a window */
+  float rho[BIGSORD + 1];
+  float err;
+  float rms;
 } Windstat;
 
-typedef struct sta_rec {  /* for stationarity measure */
+typedef struct sta_rec {/* for stationarity measure */
   float *stat;
   float *rms;
   float *rms_ratio;
 } Stat;
 
-
-typedef struct frame_rec{
+typedef struct frame_rec {
   Cross *cp;
   Dprec *dp;
   float rms;
@@ -152,6 +144,27 @@ typedef struct frame_rec{
   struct frame_rec *prev;
 } Frame;
 
-extern   Frame *alloc_frame();
+/* Function prototypes */
+void get_fast_cands(float *fdata, float *fdsdata, int ind, int step, int size,
+                    int dec, int start, int nlags, float *engref, int *maxloc,
+                    float *maxval, Cross *cp, float *peaks, int *locs,
+                    int *ncand, F0_params *par);
+float *downsample(float *input, int samsin, int state_idx, double freq,
+                  int *samsout, int decimate, int first_time, int last_time);
 
-#endif  /* JK_GET_F0_H_ */
+int get_Nframes(long buffsize, int pad, int step);
+int init_dp_f0(double freq, F0_params *par, long *buffsize, long *sdstep);
+int dp_f0(float *fdata, int buff_size, int sdstep, double freq, F0_params *par,
+          float **f0p_pt, float **vuvp_pt, float **rms_speech_pt,
+          float **acpkp_pt, int *vecsize, int last_time);
+
+Frame *alloc_frame(int nlags, int ncands);
+
+int eround(double finum);
+
+/* The RAPT interface */
+int rapt(float *input, float *output, int length, double sample_freq,
+         int frame_shift, double minF0, double maxF0, double voice_bias,
+         int otype);
+
+#endif /* JK_GET_F0_H_ */

--- a/bin/pitch/snack/jkGetF0.h
+++ b/bin/pitch/snack/jkGetF0.h
@@ -59,6 +59,8 @@
 
 /* $Id: jkGetF0.h,v 1.6 2014/12/11 08:30:43 uratec Exp $ */
 
+#ifndef JK_GET_F0_H_
+#define JK_GET_F0_H_
 
 /* f0.h */
 /* Some definitions used by the "Pitch Tracker Software". */
@@ -160,3 +162,5 @@ typedef struct _float_list {
 /* The RAPT interface */
 void rapt(float_list *input, int length, double sample_freq, int frame_shift,
      double minF0, double maxF0, double voice_bias, int otype);
+
+#endif  /* JK_GET_F0_H_ */

--- a/bin/pitch/snack/jkGetF0.h
+++ b/bin/pitch/snack/jkGetF0.h
@@ -154,16 +154,4 @@ typedef struct frame_rec{
 
 extern   Frame *alloc_frame();
 
-/****************************************************************
-    The RAPT pitch tracker
-
-        return   value :    0 -> completed normally
-                            1 -> invalid/inconsistent parameters
-                            2 -> input range too small
-                            3 -> problem in init_dp_f0
-
-*****************************************************************/
-int rapt(float *input, float* output, int length, double sample_freq,
-     int frame_shift, double minF0, double maxF0, double voice_bias, int otype);
-
 #endif  /* JK_GET_F0_H_ */

--- a/bin/pitch/snack/sigproc.c
+++ b/bin/pitch/snack/sigproc.c
@@ -81,9 +81,7 @@
  * Dout is assumed to be at least n elements long.  Type is decoded in
  * the switch statement below.
  */
-int xget_window(dout, n, type)
-     register float *dout;
-     register int n, type;
+int xget_window(register float *dout, register int n, register int type)
 {
   static float *din = NULL;
   static int n0 = 0;
@@ -108,10 +106,8 @@ int xget_window(dout, n, type)
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Apply a rectangular window (i.e. none).  Optionally, preemphasize. */
-void xrwindow(din, dout, n, preemp)
-     register float *din;
-     register float *dout, preemp;
-     register int n;
+void xrwindow(register float *din, register float *dout, register int n,
+              register float preemp)
 {
   register float *p;
 
@@ -128,10 +124,8 @@ void xrwindow(din, dout, n, preemp)
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Generate a cos^4 window, if one does not already exist. */
-void xcwindow(din, dout, n, preemp)
-     register float *din;
-     register float *dout, preemp;
-     register int n;
+void xcwindow(register float *din, register float *dout, register int n,
+              register float preemp)
 {
   register int i;
   register float *p;
@@ -165,10 +159,8 @@ void xcwindow(din, dout, n, preemp)
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Generate a Hamming window, if one does not already exist. */
-void xhwindow(din, dout, n, preemp)
-     register float *din;
-     register float *dout, preemp;
-     register int n;
+void xhwindow(register float *din, register float *dout, register int n,
+              register float preemp)
 {
   register int i;
   register float *p;
@@ -200,10 +192,8 @@ void xhwindow(din, dout, n, preemp)
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Generate a Hanning window, if one does not already exist. */
-void xhnwindow(din, dout, n, preemp)
-     register float *din;
-     register float *dout, preemp;
-     register int n;
+void xhnwindow(register float *din, register float *dout, register int n,
+               register float preemp)
 {
   register int i;
   register float *p;
@@ -238,11 +228,8 @@ void xhnwindow(din, dout, n, preemp)
  * in din.  Return the floating-point result sequence in dout.  If preemp
  * is non-zero, apply preemphasis to tha data as it is windowed.
  */
-int sigproc_window(din, dout, n, preemp, type)
-     register float *din;
-     register float *dout, preemp;
-     register int n;
-     int type;
+int sigproc_window(register float *din, register float *dout, register int n,
+                   register float preemp, int type)
 {
   switch(type) {
   case 0:			/* rectangular */
@@ -269,10 +256,8 @@ int sigproc_window(din, dout, n, preemp, type)
  * Return the normalized autocorrelation coefficients in r.
  * The rms is returned in e.
  */
-void xautoc( windowsize, s, p, r, e )
-     register int p, windowsize;
-     register float *s, *e;
-     register float *r;
+void xautoc(register int windowsize, register float *s, register int p,
+            register float *r, register float *e)
 {
   register int i, j;
   register float *q, *t, sum, sum0;
@@ -306,9 +291,8 @@ void xautoc( windowsize, s, p, r, e )
  * Note: durbin returns the coefficients in normal sign format.
  *	(i.e. a[0] is assumed to be = +1.)
  */
-void xdurbin ( r, k, a, p, ex)
-     register int p;			/* analysis order */
-     register float *r, *k, *a, *ex;
+void xdurbin(register float *r, register float *k, register float *a,
+             register int p, register float *ex)
 {
   float  bb[BIGSORD];
   register int i, j;
@@ -342,9 +326,7 @@ void xdurbin ( r, k, a, p, ex)
  *  The magnitude of a is returned in c.
  *  2* the other autocorrelation coefficients are returned in b.
  */
-void xa_to_aca ( a, b, c, p )
-float *a, *b, *c;
-register int p;
+void xa_to_aca(float *a, float *b, float *c, register int p)
 {
   register float  s, *ap, *a0;
   register int  i, j;
@@ -370,9 +352,8 @@ register int p;
  * r is assumed normalized and r[0]=1 is not explicitely accessed.
  * Values returned by the function are >= 1.
  */
-float xitakura ( p, b, c, r, gain )
-     register float *b, *c, *r, *gain;
-     register int p;
+float xitakura(register int p, register float *b, register float *c,
+               register float *r, register float *gain)
 {
   register float s;
 
@@ -387,10 +368,7 @@ float xitakura ( p, b, c, r, gain )
  * is weighted by a window of type w_type before RMS computation.  w_type
  * is decoded above in window().
  */
-float wind_energy(data,size,w_type)
-     register float *data;	/* input PCM data */
-     register int size,		/* size of window */
-       w_type;			/* window type */
+float wind_energy(register float *data, register int size, register int w_type)
 {
   static int nwind = 0;
   static float *dwind = NULL;
@@ -422,18 +400,9 @@ float wind_energy(data,size,w_type)
 /* Generic autocorrelation LPC analysis of the short-integer data
  * sequence in data.
  */
-int xlpc(lpc_ord,lpc_stabl,wsize,data,lpca,ar,lpck,normerr,rms,preemp,type)
-     int lpc_ord,		/* Analysis order */
-       wsize,			/* window size in points */
-       type;		/* window type (decoded in window() above) */
-     float lpc_stabl,	/* Stability factor to prevent numerical problems. */
-       *lpca,		/* if non-NULL, return vvector for predictors */
-       *ar,		/* if non-NULL, return vector for normalized autoc. */
-       *lpck,		/* if non-NULL, return vector for PARCOR's */
-       *normerr,		/* return scaler for normalized error */
-       *rms,		/* return scaler for energy in preemphasized window */
-       preemp;
-     float *data;	/* input data sequence; assumed to be wsize+1 long */
+int xlpc(int lpc_ord, float lpc_stabl, int wsize, float *data, float *lpca,
+         float *ar, float *lpck, float *normerr, float *rms, float preemp,
+         int type)
 {
   static float *dwind=NULL;
   static int nwind=0;
@@ -504,10 +473,8 @@ int xlpc(lpc_ord,lpc_stabl,wsize,data,lpca,ar,lpck,normerr,rms,preemp,type)
   correl is the array of nlags cross-correlation coefficients (-1.0 to 1.0)
  *
  */
-void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
-     int *maxloc;
-     float *engref, *maxval, *data, *correl;
-     int size, start, nlags;
+void crossf(float *data, int size, int start, int nlags, float *engref,
+            int *maxloc, float *maxval, float *correl)
 {
   static float *dbdata=NULL;
   static int dbsize = 0;
@@ -596,10 +563,9 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
   nlocs is the number of correlation patches to compute.
  *
  */
-void crossfi(data, size, start0, nlags0, nlags, engref, maxloc, maxval, correl, locs, nlocs)
-     int *maxloc;
-     float *engref, *maxval, *data, *correl;
-     int size, start0, nlags0, nlags, *locs, nlocs;
+void crossfi(float *data, int size, int start0, int nlags0, int nlags,
+             float *engref, int *maxloc, float *maxval, float *correl,
+             int *locs, int nlocs)
 {
   static float *dbdata=NULL;
   static int dbsize = 0;

--- a/bin/pitch/snack/sigproc.c
+++ b/bin/pitch/snack/sigproc.c
@@ -3,7 +3,7 @@
  * by Microsoft Corp. with the terms in the accompanying file BSD.txt,
  * which is a BSD style license.
  *
- *    "Copyright (c) 1990-1996 Entropic Research Laboratory, Inc. 
+ *    "Copyright (c) 1990-1996 Entropic Research Laboratory, Inc.
  *                   All rights reserved"
  *
  * Written by:  David Talkin
@@ -73,9 +73,6 @@
 # define FALSE 0
 #endif
 #include "jkGetF0.h"
-#if 0
-#include "snack.h"
-#endif /* 0 */
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Return a time-weighting window of type type and length n in dout.
@@ -93,15 +90,7 @@ int xget_window(dout, n, type)
   if(n > n0) {
     register float *p;
     register int i;
-    
-#if 0
-    if(din) ckfree((void *)din);
-    din = NULL;
-    if(!(din = (float*)ckalloc(sizeof(float)*n))) {
-      Fprintf(stderr,"Allocation problems in xget_window()\n");
-      return(FALSE);
-    }
-#else
+
     if (din) free((void *) din);
     din = NULL;
     if (!(din = (float *) malloc(sizeof(float) * n))) {
@@ -109,13 +98,12 @@ int xget_window(dout, n, type)
         return (FALSE);
     }
 
-#endif /* 0 */
     for(i=0, p=din; i++ < n; ) *p++ = 1;
     n0 = n;
   }
   return(window(din, dout, n, preemp, type));
 }
-  
+
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Apply a rectangular window (i.e. none).  Optionally, preemphasize. */
 void xrwindow(din, dout, n, preemp)
@@ -124,7 +112,7 @@ void xrwindow(din, dout, n, preemp)
      register int n;
 {
   register float *p;
- 
+
 /* If preemphasis is to be performed,  this assumes that there are n+1 valid
    samples in the input buffer (din). */
   if(preemp != 0.0) {
@@ -148,19 +136,14 @@ void xcwindow(din, dout, n, preemp)
   static int wsize = 0;
   static float *wind=NULL;
   register float *q, co;
- 
+
   if(wsize != n) {		/* Need to create a new cos**4 window? */
     register double arg, half=0.5;
-    
-#if 0
-    if(wind) wind = (float*)ckrealloc((void *)wind,n*sizeof(float));
-    else wind = (float*)ckalloc(n*sizeof(float));
-#else
+
     if (wind)
         wind = (float *) realloc((void *) wind, n * sizeof(float));
     else
         wind = (float *) malloc(n * sizeof(float));
-#endif /* 0 */
     wsize = n;
     for(i=0, arg=3.1415927*2.0/(wsize), q=wind; i < n; ) {
       co = (float) (half*(1.0 - cos((half + (double)i++) * arg)));
@@ -193,16 +176,11 @@ void xhwindow(din, dout, n, preemp)
 
   if(wsize != n) {		/* Need to create a new Hamming window? */
     register double arg, half=0.5;
-    
-#if 0
-    if(wind) wind = (float*)ckrealloc((void *)wind,n*sizeof(float));
-    else wind = (float*)ckalloc(n*sizeof(float));
-#else
+
     if (wind)
         wind = (float *) realloc((void *) wind, n * sizeof(float));
     else
         wind = (float *) malloc(n * sizeof(float));
-#endif /* 0 */
     wsize = n;
     for(i=0, arg=3.1415927*2.0/(wsize), q=wind; i < n; )
       *q++ = (float) (.54 - .46 * cos((half + (double)i++) * arg));
@@ -233,16 +211,11 @@ void xhnwindow(din, dout, n, preemp)
 
   if(wsize != n) {		/* Need to create a new Hanning window? */
     register double arg, half=0.5;
-    
-#if 0
-    if(wind) wind = (float*)ckrealloc((void *)wind,n*sizeof(float));
-    else wind = (float*)ckalloc(n*sizeof(float));
-#else
+
     if (wind)
         wind = (float *) realloc((void *) wind, n * sizeof(float));
     else
         wind = (float *) malloc(n * sizeof(float));
-#endif /* 0 */
     wsize = n;
     for(i=0, arg=3.1415927*2.0/(wsize), q=wind; i < n; )
       *q++ = (float) (half - half * cos((half + (double)i++) * arg));
@@ -362,7 +335,7 @@ void xdurbin ( r, k, a, p, ex)
 }
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
-/*  Compute the autocorrelations of the p LP coefficients in a. 
+/*  Compute the autocorrelations of the p LP coefficients in a.
  *  (a[0] is assumed to be = 1 and not explicitely accessed.)
  *  The magnitude of a is returned in c.
  *  2* the other autocorrelation coefficients are returned in b.
@@ -423,15 +396,10 @@ float wind_energy(data,size,w_type)
   register int i;
 
   if(nwind < size) {
-#if 0
-    if(dwind) dwind = (float*)ckrealloc((void *)dwind,size*sizeof(float));
-    else dwind = (float*)ckalloc(size*sizeof(float));
-#else
     if (dwind)
         dwind = (float *) realloc((void *) dwind, size * sizeof(float));
     else
         dwind = (float *) malloc(size * sizeof(float));
-#endif /* 0 */
     if(!dwind) {
       Fprintf(stderr,"Can't allocate scratch memory in wind_energy()\n");
       return(0.0);
@@ -470,24 +438,19 @@ int xlpc(lpc_ord,lpc_stabl,wsize,data,lpca,ar,lpck,normerr,rms,preemp,type)
   float rho[BIGSORD+1], k[BIGSORD], a[BIGSORD+1],*r,*kp,*ap,en,er,wfact=1.0;
 
   if((wsize <= 0) || (!data) || (lpc_ord > BIGSORD)) return(FALSE);
-  
+
   if(nwind != wsize) {
-#if 0
-    if(dwind) dwind = (float*)ckrealloc((void *)dwind,wsize*sizeof(float));
-    else dwind = (float*)ckalloc(wsize*sizeof(float));
-#else
     if (dwind)
         dwind = (float *) realloc((void *) dwind, wsize * sizeof(float));
     else
         dwind = (float *) malloc(wsize * sizeof(float));
-#endif /* 0 */
     if(!dwind) {
       Fprintf(stderr,"Can't allocate scratch memory in lpc()\n");
       return(FALSE);
     }
     nwind = wsize;
   }
-  
+
   window(data, dwind, wsize, preemp, type);
   if(!(r = ar)) r = rho;	/* Permit optional return of the various */
   if(!(kp = lpck)) kp = k;	/* coefficients and intermediate results. */
@@ -558,26 +521,14 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
      sequenced for the purposes of F0 estimation and removes the need for
      more principled (and costly) low-cut filtering. */
   if((total = size+start+nlags) > dbsize) {
-#if 0
-    if(dbdata)
-      ckfree((void *)dbdata);
-#else
     if(dbdata)
       free((void *)dbdata);
-#endif /* 0 */
     dbdata = NULL;
     dbsize = 0;
-#if 0
-    if(!(dbdata = (float*)ckalloc(sizeof(float)*total))) {
-      Fprintf(stderr,"Allocation failure in crossf()\n");
-      return;/*exit(-1);*/
-    }
-#else
     if(!(dbdata = (float*)malloc(sizeof(float)*total))) {
       Fprintf(stderr,"Allocation failure in crossf()\n");
       return;/*exit(-1);*/
     }
-#endif /* 0 */
     dbsize = total;
   }
   for(engr=0.0, j=size, p=data; j--; ) engr += *p++;
@@ -587,7 +538,7 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
   maxsize = start + nlags;
   sizei = size + start + nlags + 1;
   sizeo = nlags + 1;
- 
+
   /* Compute energy in reference window. */
   for(j=size, dp=dbdata, sum=0.0; j--; ) {
     st = *dp++;
@@ -596,7 +547,7 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
 
   *engref = engr = sum;
   if(engr > 0.0) {    /* If there is any signal energy to work with... */
-    /* Compute energy at the first requested lag. */  
+    /* Compute energy at the first requested lag. */
     for(j=size, dp=dbdata+start, sum=0.0; j--; ) {
       st = *dp++;
       sum += st * st;
@@ -632,7 +583,7 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
    compute only small patches of the correlation sequence.  The length of
    each patch is determined by nlags; the number of patches by nlocs, and
    the locations of the patches is specified by the array locs.  Regions
-   of the CCF that are not computed are set to 0. 
+   of the CCF that are not computed are set to 0.
  *
   data is the input speech array
   size is the number of samples in each correlation
@@ -664,26 +615,14 @@ void crossfi(data, size, start0, nlags0, nlags, engref, maxloc, maxval, correl, 
   /* Compute mean in reference window and subtract this from the
      entire sequence. */
   if((total = size+start0+nlags0) > dbsize) {
-#if 0
-    if(dbdata)
-      ckfree((void *)dbdata);
-#else
     if (dbdata)
         free((void *) dbdata);
-#endif /* 0 */
     dbdata = NULL;
     dbsize = 0;
-#if 0
-    if(!(dbdata = (float*)ckalloc(sizeof(float)*total))) {
-      Fprintf(stderr,"Allocation failure in crossfi()\n");
-      return;/*exit(-1);*/
-    }
-#else
     if (!(dbdata = (float *) malloc(sizeof(float) * total))) {
         Fprintf(stderr, "Allocation failure in crossf()\n");
         return;             /*exit(-1); */
     }
-#endif /* 0 */
     dbsize = total;
   }
   for(engr=0.0, j=size, p=data; j--; ) engr += *p++;
@@ -717,7 +656,7 @@ void crossfi(data, size, start0, nlags0, nlags, engref, maxloc, maxval, correl, 
       if(start < start0)
 	start = start0;
       dq = correl + start - start0;
-      /* compute energy at first requested lag */  
+      /* compute energy at first requested lag */
       for(j=size, dp=dbdata+start, sum=0.0; j--; ) {
 	st = *dp++;
 	sum += st * st;

--- a/bin/pitch/snack/sigproc.c
+++ b/bin/pitch/snack/sigproc.c
@@ -72,7 +72,9 @@
 # define TRUE 1
 # define FALSE 0
 #endif
-#include "jkGetF0.h"
+
+#include "sigproc.h"
+
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
 /* Return a time-weighting window of type type and length n in dout.
@@ -514,7 +516,6 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
   register  float *dq, t, *p, engr, *dds, amax;
   register  double engc;
   int i, iloc, total;
-  int sizei, sizeo, maxsize;
 
   /* Compute mean in reference window and subtract this from the
      entire sequence.  This doesn't do too much damage to the data
@@ -534,10 +535,6 @@ void crossf(data, size, start, nlags, engref, maxloc, maxval, correl)
   for(engr=0.0, j=size, p=data; j--; ) engr += *p++;
   engr /= size;
   for(j=size+nlags+start, dq = dbdata, p=data; j--; )  *dq++ = *p++ - engr;
-
-  maxsize = start + nlags;
-  sizei = size + start + nlags + 1;
-  sizeo = nlags + 1;
 
   /* Compute energy in reference window. */
   for(j=size, dp=dbdata, sum=0.0; j--; ) {

--- a/bin/pitch/snack/sigproc.c
+++ b/bin/pitch/snack/sigproc.c
@@ -101,7 +101,7 @@ int xget_window(dout, n, type)
     for(i=0, p=din; i++ < n; ) *p++ = 1;
     n0 = n;
   }
-  return(window(din, dout, n, preemp, type));
+  return(sigproc_window(din, dout, n, preemp, type));
 }
 
 /*+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
@@ -236,7 +236,7 @@ void xhnwindow(din, dout, n, preemp)
  * in din.  Return the floating-point result sequence in dout.  If preemp
  * is non-zero, apply preemphasis to tha data as it is windowed.
  */
-int window(din, dout, n, preemp, type)
+int sigproc_window(din, dout, n, preemp, type)
      register float *din;
      register float *dout, preemp;
      register int n;
@@ -451,7 +451,7 @@ int xlpc(lpc_ord,lpc_stabl,wsize,data,lpca,ar,lpck,normerr,rms,preemp,type)
     nwind = wsize;
   }
 
-  window(data, dwind, wsize, preemp, type);
+  sigproc_window(data, dwind, wsize, preemp, type);
   if(!(r = ar)) r = rho;	/* Permit optional return of the various */
   if(!(kp = lpck)) kp = k;	/* coefficients and intermediate results. */
   if(!(ap = lpca)) ap = a;

--- a/bin/pitch/snack/sigproc.h
+++ b/bin/pitch/snack/sigproc.h
@@ -5,6 +5,7 @@
 
 #define Fprintf (void) fprintf
 
+int xget_window(register float *dout, register int n, register int type);
 void xrwindow(register float *din, register float *dout, register int n,
               register float preemp);
 void xcwindow(register float *din, register float *dout, register int n,
@@ -15,7 +16,6 @@ void xhnwindow(register float *din, register float *dout, register int n,
                register float preemp);
 int sigproc_window(register float *din, register float *dout, register int n,
                    register float preemp, int type);
-int xget_window(register float *dout, register int n, register int type);
 void xautoc(register int windowsize, register float *s, register int p,
             register float *r, register float *e);
 void xdurbin(register float *r, register float *k, register float *a,

--- a/bin/pitch/snack/sigproc.h
+++ b/bin/pitch/snack/sigproc.h
@@ -1,0 +1,36 @@
+#ifndef SIGPROC_H_
+#define SIGPROC_H_
+
+#define BIGSORD 100
+
+#define Fprintf (void) fprintf
+
+void xrwindow(register float *din, register float *dout, register int n,
+              register float preemp);
+void xcwindow(register float *din, register float *dout, register int n,
+              register float preemp);
+void xhwindow(register float *din, register float *dout, register int n,
+              register float preemp);
+void xhnwindow(register float *din, register float *dout, register int n,
+               register float preemp);
+int sigproc_window(register float *din, register float *dout, register int n,
+                   register float preemp, int type);
+int xget_window(register float *dout, register int n, register int type);
+void xautoc(register int windowsize, register float *s, register int p,
+            register float *r, register float *e);
+void xdurbin(register float *r, register float *k, register float *a,
+             register int p, register float *ex);
+void xa_to_aca(float *a, float *b, float *c, register int p);
+float xitakura(register int p, register float *b, register float *c,
+               register float *r, register float *gain);
+float wind_energy(register float *data, register int size, register int w_type);
+int xlpc(int lpc_ord, float lpc_stabl, int wsize, float *data, float *lpca,
+         float *ar, float *lpck, float *normerr, float *rms, float preemp,
+         int type);
+void crossf(float *data, int size, int start, int nlags, float *engref,
+            int *maxloc, float *maxval, float *correl);
+void crossfi(float *data, int size, int start0, int nlags0, int nlags,
+             float *engref, int *maxloc, float *maxval, float *correl,
+             int *locs, int nlocs);
+
+#endif /* SIGPROC_H_ */

--- a/bin/pitch/swipe/swipe.c
+++ b/bin/pitch/swipe/swipe.c
@@ -522,7 +522,6 @@ void swipe(double *input, double* output, int length, int samplerate, int frame_
 #if 0
     S = zerom(pc.x, ceil(((double) x.x / nyquist2) / dt));
 #else
-    S;
     if(dt >= nyquist2){
       S = zerom(pc.x, ceil(((double) x.x / nyquist2) / dt));
     }else{

--- a/bin/pitch/swipe/swipe.c
+++ b/bin/pitch/swipe/swipe.c
@@ -548,21 +548,22 @@ void swipe(double *input, double* output, int length, int samplerate, int frame_
     for (i = 0; i < p.x; i++) {
       switch(otype) {
       case 1:      /* f0 */
-	/* fwritef(&p.v[i], sizeof(p.v[i]), 1, stdout); */
 	output[i] = p.v[i];
 	break;
       case 2:      /* log(f0) */
-	if (p.v[i] != 0.0)
+	if (p.v[i] != 0.0) {
 	  p.v[i] = log(p.v[i]);
-	else
+	} else {
 	  p.v[i] = -1.0E10;
-	/* fwritef(&p.v[i], sizeof(p.v[i]), 1, stdout); */
+	}
 	output[i] = p.v[i];
 	break;
       default:     /* pitch */
-	if (p.v[i] != 0.0)
+	if (p.v[i] != 0.0) {
 	  p.v[i] = samplerate / p.v[i];
-	/* fwritef(&p.v[i], sizeof(p.v[i]), 1, stdout); */
+	} else {
+	  p.v[i] = 0.0;
+	}
 	output[i] = p.v[i];
 	break;
       }

--- a/bin/wscript
+++ b/bin/wscript
@@ -14,12 +14,16 @@ def build(bld):
         'pitch/swipe/swipe.c',
         'pitch/swipe/vector.c',
     ]
+    rapt_src = [
+        'pitch/snack/jkGetF0.c',
+        'pitch/snack/sigproc.c',
+    ]
 
     hts_engine_src = bld.path.ant_glob('**/vc/hts_engine_API/*.c')
 
     # Collect sources
     src = list(bld.path.ant_glob('**/_*.c') +
-               swipe_src + hts_engine_src + lib_src)
+               swipe_src + rapt_src + hts_engine_src + lib_src)
 
     # NOTE: Since wavjoin and wavsplit use direct.h, which only exists in POSIX
     # environments, I ignore these files to compile for cross-platform compilation

--- a/include/SPTK.h
+++ b/include/SPTK.h
@@ -395,6 +395,18 @@ void excite(double *pitch, int n, double *out, int fprd, int iprd, Boolean gauss
 
 void swipe(double *input, double *output, int length, int samplerate, int frame_shift, double min, double max, double st, int otype);
 
+/****************************************************************
+    The RAPT pitch tracker
+
+        return   value :    0 -> completed normally
+                            1 -> invalid/inconsistent parameters
+                            2 -> input range too small
+                            3 -> problem in init_dp_f0
+
+*****************************************************************/
+int rapt(float *input, float* output, int length, double sample_freq,
+     int frame_shift, double minF0, double maxF0, double voice_bias, int otype);
+
 void b2c(double *b, int m1, double *c, int m2, double a);
 
 

--- a/include/SPTK.h
+++ b/include/SPTK.h
@@ -49,6 +49,9 @@
    SPTK.h
 ***********************************************************/
 
+#ifndef SPTK_H_
+#define SPTK_H_
+
 #ifndef DLLEXPORT
 #  ifdef _WIN32
 #      define DLLEXPORT __declspec(dllexport)
@@ -393,3 +396,6 @@ void excite(double *pitch, int n, double *out, int fprd, int iprd, Boolean gauss
 void swipe(double *input, double *output, int length, int samplerate, int frame_shift, double min, double max, double st, int otype);
 
 void b2c(double *b, int m1, double *c, int m2, double a);
+
+
+#endif  /* SPTK_H_ */

--- a/wscript
+++ b/wscript
@@ -31,11 +31,11 @@ def configure(conf):
     if re.search('clang', conf.env.CC[0]):
         conf.env.append_unique(
             'CFLAGS',
-            ['-O3', '-Wall', '-fno-common', '-ansi'])
+            ['-O3', '-Wall', '-fno-common', '-Wstrict-prototypes', '-ansi'])
     elif re.search('gcc', conf.env.CC[0]):
         conf.env.append_unique(
             'CFLAGS',
-            ['-O2', '-Wall', '-fno-common', '-ansi'])
+            ['-O2', '-Wall', '-fno-common', '-Wstrict-prototypes', '-ansi'])
     elif re.search('cl.exe', conf.env.CC[0].lower()):
         conf.env.append_unique('CFLAGS', [''])
     else:


### PR DESCRIPTION
This PR is motivated by https://github.com/r9y9/pysptk/issues/30

Summary:

- Remove if 0 else endif since it is no longer used
- Remove weird linked list and use array instead
- Add include guard to SPTK.h and jkGetF0.h
- A few memory leak fixes of RAPT

TODOs:

- [x] decide that which I should define rapt function prototype to SPTK.h or jkGetF0.h
- [x] make rapt into libSPTK
- [x] pass build on windows (~~perhaps will fail for now~~)
- [x] remove compiler warnings as possible.
- [x] regression test in pysptk https://github.com/r9y9/pysptk/issues/32

I will make a PR to pysptk with a Cython wrapper.

cc: @jfsantos 